### PR TITLE
Add a quickly put together Rust version

### DIFF
--- a/primes.rs
+++ b/primes.rs
@@ -1,0 +1,68 @@
+use std::env;
+use std::time::{Instant, Duration};
+
+const PRIMES_COUNT: u32 = 10000000;
+
+fn get_primes7(count: u32) -> Vec<u32> {
+    if count < 2 {
+        return vec![];
+    } else if count == 2 {
+        return vec![2];
+    }
+
+    let mut s = Vec::with_capacity(count as usize / 2);
+    let mut i = 3;
+    while i < count+1 {
+        s.push(i);
+        i += 2;
+    }
+
+    let mroot = (count as f32).sqrt() as u32;
+    let half = s.len() as u32;
+
+    let mut i: u32 = 0;
+    let mut m: u32 = 3;
+
+    while m <= mroot {
+        if s.get(i as usize).is_some() && s[i as usize] != 0 {
+            let mut j = (m*m-3)/2;
+            s[j as usize] = 0;
+            while j < half {
+                s[j as usize] = 0;
+                j += m;
+            }
+        }
+        i += 1;
+        m = 2*i+3;
+    }
+
+    //s.push(2);
+    //s.retain(|&x| x != 0);
+    //s
+
+    //let mut res = Vec::with_capacity(count as usize /2);
+    let mut res = Vec::new();
+    res.push(2);
+    res.extend(s.into_iter().filter(|x| *x != 0));
+    res
+}
+
+fn main() {
+    let run_time_secs = match env::var("RUN_TIME") {
+        Ok(v) => match v.parse::<u32>() {
+            Ok(i) => i,
+            Err(err) => panic!("RUN_TIME environment variable error: {}", err),
+        },
+        Err(err) => panic!("RUN_TIME environment variable error: {}", err),
+    };
+
+    let run_time = Duration::new(run_time_secs as u64, 0);
+    let start = Instant::now();
+
+    while start.elapsed() < run_time {
+	    let primes = get_primes7(PRIMES_COUNT);
+        println!("Found {} prime numbers.", primes.len());
+    }
+}
+
+

--- a/primes.rs
+++ b/primes.rs
@@ -10,7 +10,7 @@ fn get_primes7(count: u32) -> Vec<u32> {
         return vec![2];
     }
 
-    let mut s = Vec::with_capacity(count as usize / 2);
+    let mut s = Vec::new();
     let mut i = 3;
     while i < count+1 {
         s.push(i);
@@ -36,11 +36,6 @@ fn get_primes7(count: u32) -> Vec<u32> {
         m = 2*i+3;
     }
 
-    //s.push(2);
-    //s.retain(|&x| x != 0);
-    //s
-
-    //let mut res = Vec::with_capacity(count as usize /2);
     let mut res = Vec::new();
     res.push(2);
     res.extend(s.into_iter().filter(|x| *x != 0));
@@ -64,5 +59,4 @@ fn main() {
         println!("Found {} prime numbers.", primes.len());
     }
 }
-
 

--- a/run.sh
+++ b/run.sh
@@ -134,3 +134,9 @@ C='nodejs' ; SRC='primes.js' ; run_benchmark 'JavaScript (nodejs)' 'true' "$C $S
 ##
 
 C='ruby' ; SRC='primes.rb' ; run_benchmark 'Ruby' 'true' "$C $SRC" "$C -v" 'cat' "$SRC"
+
+##
+
+# -C opt-level=3 is the default opt level for the code produced by the --release target.
+C='rust'; SRC='primes.rs' ; run_benchmark 'Rust' 'rustc -C opt-level=3 -o primes.rs.out primes.rs' './primes.rs.out' 'rustc -V' 'head -n1' "$SRC"
+rm -f primes.rs.out


### PR DESCRIPTION
Quickly put together Rust version. This is probably not very idiomatic Rust but should be close to the other examples.
Written for stable rust so should work on nightly as well (use rustup.rs : `curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain stable` to install )
